### PR TITLE
add inline & block extensions for markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is Picosite, a *minimalist* static site generator.
 
 Picosite is published as a single, stand alone executable. You can get a copy of the latest version from: .
 
+The [documentation for picosite](doc/) also serves as an example of how to use picosite.
+
 ## Acknowledgements
 
 My thanks to @munificent for his [Markymark package](https://github.com/munificent/markymark), which was the starting point for Picosite.

--- a/lib/content.dart
+++ b/lib/content.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:io/io.dart';
+import 'package:markdown/markdown.dart';
 import 'package:mustache_template/mustache.dart';
 import 'package:path/path.dart' as p;
 import "package:markdown/markdown.dart" as m;
@@ -64,7 +65,18 @@ Future<String> processMarkdown(final String markdownDoc, final String title,
   }
   print("finished processing:$title");
 
-  docVariables['body'] = m.markdownToHtml(markdownBody);
+  docVariables['body'] = m.markdownToHtml(
+    markdownBody,
+    inlineSyntaxes: [
+      InlineHtmlSyntax(),
+    ],
+    blockSyntaxes: [
+      TableSyntax(),
+      FencedCodeBlockSyntax(),
+      HeaderWithIdSyntax(),
+      HorizontalRuleSyntax(),
+    ],
+  );
 
   Template? partialsFileResolver(String name) {
     final partial = File(p.join(partialsPath, name)).readAsStringSync();


### PR DESCRIPTION
Added extensions for markdown for:
* tables
* fenced code blocks 
* headers with html IDs
* inline html